### PR TITLE
Corrige la importación de JoinModel en VariantLocation.php

### DIFF
--- a/Model/Join/VariantLocation.php
+++ b/Model/Join/VariantLocation.php
@@ -20,7 +20,7 @@
 
 namespace FacturaScripts\Plugins\Ubicaciones\Model\Join;
 
-use FacturaScripts\Dinamic\Model\Base\JoinModel;
+use FacturaScripts\Core\Template\JoinModel;
 use FacturaScripts\Dinamic\Model\VariantLocation as VariantLocationModel;
 
 /**


### PR DESCRIPTION
Se actualiza la importación de JoinModel para utilizar la clase correcta desde FacturaScripts\Core\Template en lugar de FacturaScripts\Dinamic\Model\Base.